### PR TITLE
improve TIP following cpu usage, upgrade to boost.1.84

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -1,9 +1,9 @@
 package=boost
-$(package)_version=1_71_0
-# $(package)_download_path=https://boostorg.jfrog.io/artifactory/main/release/$(subst _,.,$($(package)_version))/source/
-$(package)_download_path=https://github.com/decenomy/depends/raw/main/
+$(package)_version=1_84_0
+$(package)_download_path=https://boostorg.jfrog.io/artifactory/main/release/$(subst _,.,$($(package)_version))/source/
+# $(package)_download_path=https://github.com/decenomy/depends/raw/main/
 $(package)_file_name=boost_$($(package)_version).tar.bz2
-$(package)_sha256_hash=d73a8da01e8bf8c7eda40b4c84915071a8c8a0df4a6734537ddde4a8580524ee
+$(package)_sha256_hash=cc4b893acf645c9d4b698e9a0f08ca8846aa5d6c68275c14c3e7949c24109454
 $(package)_patches=fix_gcc_11_3_compile.patch
 
 define $(package)_set_vars
@@ -31,8 +31,7 @@ $(package)_cxxflags_linux=-fPIC
 endef
 
 define $(package)_preprocess_cmds
-  echo "using $(boost_toolset_$(host_os)) : : $($(package)_cxx) : <cxxflags>\"$($(package)_cxxflags) $($(package)_cppflags)\" <linkflags>\"$($(package)_ldflags)\" <archiver>\"$(boost_archiver_$(host_os))\" <striper>\"$(host_STRIP)\"  <ranlib>\"$(host_RANLIB)\" <rc>\"$(host_WINDRES)\" : ;" > user-config.jam && \
-  patch -p1 -i $($(package)_patch_dir)/fix_gcc_11_3_compile.patch
+  echo "using $(boost_toolset_$(host_os)) : : $($(package)_cxx) : <cxxflags>\"$($(package)_cxxflags) $($(package)_cppflags)\" <linkflags>\"$($(package)_ldflags)\" <archiver>\"$(boost_archiver_$(host_os))\" <striper>\"$(host_STRIP)\"  <ranlib>\"$(host_RANLIB)\" <rc>\"$(host_WINDRES)\" : ;" > user-config.jam
 endef
 
 define $(package)_config_cmds

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -23,6 +23,7 @@
 #include <signal.h>
 #include <future>
 
+#include <deque>
 #include <event2/event.h>
 #include <event2/http.h>
 #include <event2/thread.h>

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -5,6 +5,7 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+
 #include "clientmodel.h"
 
 #include "bantablemodel.h"
@@ -28,6 +29,8 @@
 #include <QDateTime>
 #include <QDebug>
 #include <QTimer>
+
+using namespace boost::placeholders;
 
 static const int64_t nClientStartupTime = GetTime();
 // Last tip update notification

--- a/src/qt/pivx/pivxgui.cpp
+++ b/src/qt/pivx/pivxgui.cpp
@@ -36,6 +36,7 @@
 #define BASE_WINDOW_MIN_HEIGHT 620
 #define BASE_WINDOW_MIN_WIDTH 1100
 
+using namespace boost::placeholders;
 
 const QString PIVXGUI::DEFAULT_WALLET = "~Default";
 

--- a/src/qt/pivx/splash.cpp
+++ b/src/qt/pivx/splash.cpp
@@ -24,6 +24,8 @@
 
 #include <iostream>
 
+using namespace boost::placeholders;
+
 Splash::Splash(Qt::WindowFlags f, const NetworkStyle* networkStyle) :
     QWidget(0, f | Qt::SplashScreen), ui(new Ui::Splash)
 {

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -30,6 +30,8 @@
 #include <QtConcurrent/QtConcurrent>
 #include <QFuture>
 
+using namespace boost::placeholders;
+
 // Amount column is right-aligned it contains numbers
 static int column_alignments[] = {
     Qt::AlignLeft | Qt::AlignVCenter, /* status */

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -29,6 +29,7 @@
 #include <QSet>
 #include <QTimer>
 
+using namespace boost::placeholders;
 
 WalletModel::WalletModel(CWallet* wallet, OptionsModel* optionsModel, QObject* parent) : QObject(parent), wallet(wallet), walletWrapper(*wallet),
                                                                                          optionsModel(optionsModel),

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -7,6 +7,8 @@
 
 #include "validationinterface.h"
 
+using namespace boost::placeholders;
+
 static CMainSignals g_signals;
 
 CMainSignals& GetMainSignals()

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -24,7 +24,6 @@
 #include <boost/thread.hpp>
 #include <fstream>
 
-
 static uint64_t nAccountingEntryNumber = 0;
 
 static std::atomic<unsigned int> nWalletDBUpdateCounter;
@@ -1069,7 +1068,9 @@ bool AttemptBackupWallet(const CWallet& wallet, const fs::path& pathSrc, const f
             LogPrintf("cannot backup to wallet source file %s\n", pathDest.string());
             return false;
         }
-#if BOOST_VERSION >= 105800 /* BOOST_LIB_VERSION 1_58 */
+#if BOOST_VERSION >= 107400 /* BOOST_LIB_VERSION 1_74 */
+        fs::copy_file(pathSrc.c_str(), pathDest, fs::copy_options::overwrite_existing);
+#elif BOOST_VERSION >= 105800 /* BOOST_LIB_VERSION 1_58 */
         fs::copy_file(pathSrc.c_str(), pathDest, fs::copy_option::overwrite_if_exists);
 #else
         std::ifstream src(pathSrc.c_str(),  std::ios::binary | std::ios::in);


### PR DESCRIPTION
problem: qt daemon uses significant cpu resources while following the tip.
solution: update /depends/ boost library to 1.84 to take advantage of new Boost.Unordered improvements

observed improvement on 3.6 ghz Xeon 12 real (24 virtual) core processor
BEFORE: periods of 15 - 30 minutes with 100% of a single virtual core in use, GUI unresponsive for minutes at a time
AFTER: a few seconds of <35-58% cpu utilization occasionally

change main.h
	typedef BlockMap ... mapBlockIndex
from std::unordered_map to boost::unordered_map
to take advantage of reduced cpu usage during "tip" following.

see benchmark info:
https://www.boost.org/doc/libs/develop/libs/unordered/doc/html/unordered.html#buckets_benchmarks
https://medium.com/@pavel.odintsov/boost-unordered-map-is-a-new-king-of-data-structures-292124d3ee2